### PR TITLE
soong: Add power libperfmgr extension config

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -218,6 +218,25 @@ vendor_init {
 }
 
 soong_config_module_type {
+    name: "power_libperfmgr",
+    module_type: "cc_defaults",
+    config_namespace: "lineageGlobalVars",
+    value_variables: ["target_power_libperfmgr_mode_extension_lib"],
+    properties: [
+        "whole_static_libs",
+    ],
+}
+
+power_libperfmgr {
+    name: "power_libperfmgr_defaults",
+    soong_config_variables: {
+        target_power_libperfmgr_mode_extension_lib: {
+            whole_static_libs: ["%s"],
+        },
+    },
+}
+
+soong_config_module_type {
     name: "surfaceflinger_udfps_lib",
     module_type: "cc_defaults",
     config_namespace: "infinityGlobalVars",

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -50,6 +50,7 @@ SOONG_CONFIG_infinityGlobalVars += \
     target_init_vendor_lib \
     target_inputdispatcher_skip_event_key \
     target_ld_shim_libs \
+    target_power_libperfmgr_mode_extension_lib \
     target_surfaceflinger_udfps_lib \
     target_trust_usb_control_path \
     target_trust_usb_control_enable \
@@ -117,6 +118,7 @@ TARGET_HEALTH_CHARGING_CONTROL_SUPPORTS_BYPASS ?= true
 TARGET_HEALTH_CHARGING_CONTROL_SUPPORTS_DEADLINE ?= false
 TARGET_HEALTH_CHARGING_CONTROL_SUPPORTS_TOGGLE ?= true
 TARGET_INIT_VENDOR_LIB ?= vendor_init
+TARGET_POWER_LIBPERFMGR_MODE_EXTENSION_LIB ?= libperfmgr-ext
 TARGET_QTI_VIBRATOR_EFFECT_LIB ?= libqtivibratoreffect
 TARGET_SDMCORE_HAS_IS_DISPLAY_HW_AVAILABLE_FUNC ?= true
 TARGET_SURFACEFLINGER_UDFPS_LIB ?= surfaceflinger_udfps_lib
@@ -138,6 +140,7 @@ SOONG_CONFIG_infinityGlobalVars_target_health_charging_control_supports_toggle :
 SOONG_CONFIG_infinityGlobalVars_target_init_vendor_lib := $(TARGET_INIT_VENDOR_LIB)
 SOONG_CONFIG_infinityGlobalVars_target_inputdispatcher_skip_event_key := $(TARGET_INPUTDISPATCHER_SKIP_EVENT_KEY)
 SOONG_CONFIG_infinityGlobalVars_target_ld_shim_libs := $(subst $(space),:,$(TARGET_LD_SHIM_LIBS))
+SOONG_CONFIG_lineageGlobalVars_target_power_libperfmgr_mode_extension_lib := $(TARGET_POWER_LIBPERFMGR_MODE_EXTENSION_LIB)
 SOONG_CONFIG_infinityGlobalVars_target_surfaceflinger_udfps_lib := $(TARGET_SURFACEFLINGER_UDFPS_LIB)
 SOONG_CONFIG_infinityGlobalVars_target_trust_usb_control_path := $(TARGET_TRUST_USB_CONTROL_PATH)
 SOONG_CONFIG_infinityGlobalVars_target_trust_usb_control_enable := $(TARGET_TRUST_USB_CONTROL_ENABLE)

--- a/infinity.devices
+++ b/infinity.devices
@@ -45,3 +45,4 @@ ruby
 sunny
 cheetah
 panther
+avicii


### PR DESCRIPTION
error: hardware/infinity/interfaces/power-libperfmgr/Android.bp:14:1: "android.hardware.power-service.lineage-libperfmgr" depends on undefined module "power_libperfmgr_defaults".
Or did you mean ["carpowerpolicyserver_test" "libpowermanager_benchmarks"]?
fatal errors encountered
